### PR TITLE
chore: link to opensource.yoda.digital portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # gacli
 
+[![Listed on Yoda Digital Open Source](https://img.shields.io/badge/listed%20on-opensource.yoda.digital-af9568?style=flat-square)](https://opensource.yoda.digital/projects/gacli/)
 [![CI](https://github.com/nalyk/gacli/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/nalyk/gacli/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@nalyk/gacli?color=cb3837&logo=npm)](https://www.npmjs.com/package/@nalyk/gacli)
 [![License: MIT](https://img.shields.io/github/license/nalyk/gacli?color=blue)](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "Ion (Nalyk) Calmîș",
-  "homepage": "https://github.com/nalyk/gacli#readme",
+  "homepage": "https://opensource.yoda.digital/projects/gacli/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nalyk/gacli.git"


### PR DESCRIPTION
Adds a portal backlink to README + updates package.json `homepage` field to the project's page on https://opensource.yoda.digital. Pure metadata change — no source files touched.